### PR TITLE
joyent/joyent-repos#6 `jr github-settings set-branch-protection` crashes on a repo with no current "master" branch protection

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,11 @@
 
 (nothing yet)
 
+## 2.2.1
+
+- Fix `jr github-settings set-branch-protection` handling on a repo that
+  has *no* current "master" branch protection.
+
 ## 2.2.0
 
 - Add `jr github-settings set-branch-protection`.

--- a/lib/cli/github_settings/do_set_branch_protection.js
+++ b/lib/cli/github_settings/do_set_branch_protection.js
@@ -104,24 +104,36 @@ function do_set_branch_protection(subcmd, opts, args, cb) {
                 },
 
                 function determineIfChangeRequired(ctx, next) {
+                    log.trace(
+                        {masterProt: ctx.masterProt},
+                        'determineIfChangeRequired'
+                    );
                     ctx.changeRequired = false;
-                    var pr = ctx.masterProt.required_pull_request_reviews;
-                    if (!pr) {
+                    if (!ctx.masterProt) {
                         ctx.changeRequired = true;
                     } else {
-                        if (pr.dismiss_stale_reviews !== true) {
+                        var pr = ctx.masterProt.required_pull_request_reviews;
+                        if (!pr) {
                             ctx.changeRequired = true;
-                        } else if (pr.require_code_owner_reviews !== false) {
-                            ctx.changeRequired = true;
-                        } else if (pr.required_approving_review_count !== 1) {
+                        } else {
+                            if (pr.dismiss_stale_reviews !== true) {
+                                ctx.changeRequired = true;
+                            } else if (
+                                pr.require_code_owner_reviews !== false
+                            ) {
+                                ctx.changeRequired = true;
+                            } else if (
+                                pr.required_approving_review_count !== 1
+                            ) {
+                                ctx.changeRequired = true;
+                            }
+                        }
+                        if (ctx.masterProt.enforce_admins.enabled !== true) {
                             ctx.changeRequired = true;
                         }
-                    }
-                    if (ctx.masterProt.enforce_admins.enabled !== true) {
-                        ctx.changeRequired = true;
-                    }
-                    if (ctx.masterProt.restrictions) {
-                        ctx.changeRequired = true;
+                        if (ctx.masterProt.restrictions) {
+                            ctx.changeRequired = true;
+                        }
                     }
                     log.debug(
                         {changeRequired: ctx.changeRequired},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joyent-repos",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "A spec and tool for listing, clone, and working with Joyent (Triton, Manta, and SmartOS) repos",
   "author": "Joyent (joyent.com)",
   "license": "MPL-2.0",


### PR DESCRIPTION
Fixes #6