### PR TITLE
MANTA-4799 add branch protections on "mantav1" branches of the relevant manta repos

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,12 +2,12 @@
 
 ## not yet released
 
-## 2.3.1
+## 2.4.0
 
 - `MANTA-4799 add branch protections on "mantav1" branches of the relevant manta repos`
   This updates the `jr gh` `check` and `set-branch-protection` subcommands so
-  that they also operate on the `mantav1` branch of the given repository or
-  repositories, if that branch exists.
+  that they also operate on the `mantav1` branch protection settings of the
+  given repository or repositories, if that branch exists.
 
 ## 2.3.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,13 @@
 
 ## not yet released
 
+## 2.3.1
+
+- `MANTA-4799 add branch protections on "mantav1" branches of the relevant manta repos`
+  This updates the `jr gh` `check` and `set-branch-protection` subcommands so
+  that they also operate on the `mantav1` branch of the given repository or
+  repositories, if that branch exists.
+
 ## 2.3.0
 
 - `TOOLS-2372 need a tool to toggle branch protection rules for illumos-joyent`

--- a/lib/cli/github_settings/do_check.js
+++ b/lib/cli/github_settings/do_check.js
@@ -142,9 +142,9 @@ function checkBranchProtection(branchName, ctx, next) {
     assert.object(ctx.log, 'ctx.log');
     assert.object(ctx.octokit, 'ctx.octokit');
     assert.object(ctx.repo, 'ctx.repo');
-    assert.array(ctx.checkFailures, 'ctx.checkFailures');
-    assert.array(ctx.checkWarnings, 'ctx.checkWarnings');
-    assert.array(ctx.optionalBranches, 'ctx.optionalBranches');
+    assert.arrayOfObject(ctx.checkFailures, 'ctx.checkFailures');
+    assert.arrayOfObject(ctx.checkWarnings, 'ctx.checkWarnings');
+    assert.arrayOfString(ctx.optionalBranches, 'ctx.optionalBranches');
     // https://octokit.github.io/rest.js/#octokit-routes-repos-get-branch-protection
     // https://developer.github.com/v3/repos/branches/#get-branch-protection
     //
@@ -298,8 +298,6 @@ function checkBranchProtection(branchName, ctx, next) {
                 );
             }
         });
-    // TODO: add merge button check (get repo api)
-    // TODO: add wiki check (get repo api)
 }
 
 function checkRepo(opts, cb) {
@@ -322,6 +320,8 @@ function checkRepo(opts, cb) {
                 function checkMantaV1BranchProtection(ctx, next) {
                     checkBranchProtection('mantav1', ctx, next);
                 }
+                // TODO: add merge button check (get repo api)
+                // TODO: add wiki check (get repo api)
             ]
         },
         function finish(err) {

--- a/lib/cli/github_settings/do_check.js
+++ b/lib/cli/github_settings/do_check.js
@@ -12,11 +12,23 @@ var version = require('../../../package.json').version;
 
 // Print a check failure.
 function printFail(fail) {
-    console.log('%s: error (%s): %s', fail.repo, fail.name, fail.msg);
+    console.log(
+        '%s#%s: error (%s): %s',
+        fail.repo,
+        fail.branch,
+        fail.name,
+        fail.msg
+    );
 }
 
 function printWarn(warn) {
-    console.log('%s: warning (%s): %s', warn.repo, warn.name, warn.msg);
+    console.log(
+        '%s#%s: warning (%s): %s',
+        warn.repo,
+        warn.branch,
+        warn.name,
+        warn.msg
+    );
 }
 
 function do_check(subcmd, opts, args, cb) {
@@ -123,175 +135,200 @@ function do_check(subcmd, opts, args, cb) {
     );
 }
 
+function checkBranchProtection(branchName, ctx, next) {
+    assert.string(branchName, 'branchName');
+    assert.object(ctx, 'ctx');
+    assert.func(next, 'next');
+    assert.object(ctx.log, 'ctx.log');
+    assert.object(ctx.octokit, 'ctx.octokit');
+    assert.object(ctx.repo, 'ctx.repo');
+    assert.array(ctx.checkFailures, 'ctx.checkFailures');
+    assert.array(ctx.checkWarnings, 'ctx.checkWarnings');
+    assert.array(ctx.optionalBranches, 'ctx.optionalBranches');
+    // https://octokit.github.io/rest.js/#octokit-routes-repos-get-branch-protection
+    // https://developer.github.com/v3/repos/branches/#get-branch-protection
+    //
+    // Example: "master" branch protection on "joyent/play" repo:
+    // https://github.com/joyent/play/settings/branch_protection_rules/11155545
+    //
+    // ```
+    // $ hub api /repos/joyent/play/branches/master/protection -H 'Accept:application/vnd.github.luke-cage-preview+json' | json
+    // {
+    //   "url": "https://api.github.com/repos/joyent/play/branches/master/protection",
+    //   "required_status_checks": {
+    //     "url": "https://api.github.com/repos/joyent/play/branches/master/protection/required_status_checks",
+    //     "strict": true,
+    //     "contexts": [],
+    //     "contexts_url": "https://api.github.com/repos/joyent/play/branches/master/protection/required_status_checks/contexts"
+    //   },
+    //   "required_pull_request_reviews": {
+    //     "url": "https://api.github.com/repos/joyent/play/branches/master/protection/required_pull_request_reviews",
+    //     "dismiss_stale_reviews": true,
+    //     "require_code_owner_reviews": false,
+    //     "required_approving_review_count": 1
+    //   },
+    //   "enforce_admins": {
+    //     "url": "https://api.github.com/repos/joyent/play/branches/master/protection/enforce_admins",
+    //     "enabled": true
+    //   }
+    // }
+    // ```
+    //
+    // For now, the important ones for us are:
+    //
+    // - "required_pull_request_reviews": {
+    //     "dismiss_stale_reviews": true,
+    //     "require_code_owner_reviews": false,
+    //     "required_approving_review_count": 1
+    // - "enforce_admins": {
+    //     "enabled": true
+    // - "restrictions" should not be set
+    //
+    // We are *not yet* requiring *required* status checks mainly
+    // because our PR check story is not yet decided. See
+    // https://jira.joyent.us/browse/MANTA-4598
+    //
+    // - "required_status_checks": {
+    //     "strict": true,
+    //     "contexts": ["continuous-integration/jenkins/pr-head"],
+    ctx.octokit.repos
+        .getBranchProtection({
+            owner: 'joyent',
+            repo: ctx.repo.name,
+            branch: branchName
+        })
+        .then(function(res) {
+            ctx.log.trace({ghRes: res}, 'github api response');
+            var prot = res.data;
+            var pr = prot.required_pull_request_reviews;
+            if (!pr) {
+                ctx.checkFailures.push({
+                    repo: ctx.repo.name,
+                    branch: branchName,
+                    name: 'branch_protection.required_pull_request_reviews',
+                    msg:
+                        '"Require pull request reviews before merging" must be checked'
+                });
+            } else {
+                if (pr.dismiss_stale_reviews !== true) {
+                    ctx.checkFailures.push({
+                        repo: ctx.repo.name,
+                        branch: branchName,
+                        name:
+                            'branch_protection.required_pull_request_reviews.dismiss_stale_reviews',
+                        msg:
+                            '"Dismiss stale pull request approvals when new commits are pushed" must be checked'
+                    });
+                }
+                if (pr.require_code_owner_reviews !== false) {
+                    ctx.checkFailures.push({
+                        repo: ctx.repo.name,
+                        branch: branchName,
+                        name:
+                            'branch_protection.required_pull_request_reviews.require_code_owner_reviews',
+                        msg:
+                            '"Require review from Code Owners" must not be checked'
+                    });
+                }
+                if (pr.required_approving_review_count !== 1) {
+                    ctx.checkFailures.push({
+                        repo: ctx.repo.name,
+                        branch: branchName,
+                        name:
+                            'branch_protection.required_pull_request_reviews.required_approving_review_count',
+                        msg: '"Required approving reviews" must be set to 1'
+                    });
+                }
+            }
+            if (prot.enforce_admins.enabled !== true) {
+                ctx.checkFailures.push({
+                    repo: ctx.repo.name,
+                    branch: branchName,
+                    name: 'branch_protection.enforce_admins.enabled',
+                    msg: '"Include administrators" must be checked'
+                });
+            }
+            if (prot.restrictions) {
+                ctx.checkFailures.push({
+                    repo: ctx.repo.name,
+                    branch: branchName,
+                    name: 'branch_protection.restrictions',
+                    msg:
+                        '"Restrict who can push to matching branches" must not be checked'
+                });
+            }
+
+            next();
+        })
+        .catch(function(err) {
+            if (err.message === 'Branch not protected') {
+                ctx.checkFailures.push({
+                    repo: ctx.repo.name,
+                    branch: branchName,
+                    name: 'branch_protection',
+                    msg: 'Must have "' + branchName + '" branch protection'
+                });
+                next();
+            } else if (err.message === 'Branch not found') {
+                if (ctx.optionalBranches.indexOf(branchName) === -1) {
+                    ctx.checkWarnings.push({
+                        repo: ctx.repo.name,
+                        branch: branchName,
+                        name: 'branch_protection',
+                        msg: 'No "' + branchName + '" branch (skipping)'
+                    });
+                }
+                next();
+            } else {
+                // Avoid deprecation warning by wrapping the error but
+                // still allowing cmdln to use `err.code`.
+                //   Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
+                next(
+                    new VError(
+                        {
+                            name: 'GitHubApiError',
+                            cause: err,
+                            code: err.status,
+                            info: {
+                                repo: 'joyent/' + ctx.repo.name
+                            }
+                        },
+                        'error calling GitHub API'
+                    )
+                );
+            }
+        });
+    // TODO: add merge button check (get repo api)
+    // TODO: add wiki check (get repo api)
+}
+
 function checkRepo(opts, cb) {
-    var checkFailures = [];
-    var checkWarnings = [];
-    var log = opts.log;
-    var octokit = opts.octokit;
-    var repo = opts.repo;
+    var checkOpts = {
+        checkFailures: [],
+        checkWarnings: [],
+        log: opts.log,
+        octokit: opts.octokit,
+        repo: opts.repo,
+        optionalBranches: ['mantav1']
+    };
 
     vasync.pipeline(
         {
+            arg: checkOpts,
             funcs: [
-                // https://octokit.github.io/rest.js/#octokit-routes-repos-get-branch-protection
-                // https://developer.github.com/v3/repos/branches/#get-branch-protection
-                //
-                // Example: "master" branch protection on "joyent/play" repo:
-                // https://github.com/joyent/play/settings/branch_protection_rules/11155545
-                //
-                // ```
-                // $ hub api /repos/joyent/play/branches/master/protection -H 'Accept:application/vnd.github.luke-cage-preview+json' | json
-                // {
-                //   "url": "https://api.github.com/repos/joyent/play/branches/master/protection",
-                //   "required_status_checks": {
-                //     "url": "https://api.github.com/repos/joyent/play/branches/master/protection/required_status_checks",
-                //     "strict": true,
-                //     "contexts": [],
-                //     "contexts_url": "https://api.github.com/repos/joyent/play/branches/master/protection/required_status_checks/contexts"
-                //   },
-                //   "required_pull_request_reviews": {
-                //     "url": "https://api.github.com/repos/joyent/play/branches/master/protection/required_pull_request_reviews",
-                //     "dismiss_stale_reviews": true,
-                //     "require_code_owner_reviews": false,
-                //     "required_approving_review_count": 1
-                //   },
-                //   "enforce_admins": {
-                //     "url": "https://api.github.com/repos/joyent/play/branches/master/protection/enforce_admins",
-                //     "enabled": true
-                //   }
-                // }
-                // ```
-                //
-                // For now, the important ones for us are:
-                //
-                // - "required_pull_request_reviews": {
-                //     "dismiss_stale_reviews": true,
-                //     "require_code_owner_reviews": false,
-                //     "required_approving_review_count": 1
-                // - "enforce_admins": {
-                //     "enabled": true
-                // - "restrictions" should not be set
-                //
-                // We are *not yet* requiring *required* status checks mainly
-                // because our PR check story is not yet decided. See
-                // https://jira.joyent.us/browse/MANTA-4598
-                //
-                // - "required_status_checks": {
-                //     "strict": true,
-                //     "contexts": ["continuous-integration/jenkins/pr-head"],
-                function checkMasterBranchProtection(_, next) {
-                    octokit.repos
-                        .getBranchProtection({
-                            owner: 'joyent',
-                            repo: repo.name,
-                            branch: 'master'
-                        })
-                        .then(function(res) {
-                            log.trace({ghRes: res}, 'github api response');
-                            var prot = res.data;
-                            var pr = prot.required_pull_request_reviews;
-                            if (!pr) {
-                                checkFailures.push({
-                                    repo: repo.name,
-                                    name:
-                                        'branch_protection.required_pull_request_reviews',
-                                    msg:
-                                        '"Require pull request reviews before merging" must be checked'
-                                });
-                            } else {
-                                if (pr.dismiss_stale_reviews !== true) {
-                                    checkFailures.push({
-                                        repo: repo.name,
-                                        name:
-                                            'branch_protection.required_pull_request_reviews.dismiss_stale_reviews',
-                                        msg:
-                                            '"Dismiss stale pull request approvals when new commits are pushed" must be checked'
-                                    });
-                                }
-                                if (pr.require_code_owner_reviews !== false) {
-                                    checkFailures.push({
-                                        repo: repo.name,
-                                        name:
-                                            'branch_protection.required_pull_request_reviews.require_code_owner_reviews',
-                                        msg:
-                                            '"Require review from Code Owners" must not be checked'
-                                    });
-                                }
-                                if (pr.required_approving_review_count !== 1) {
-                                    checkFailures.push({
-                                        repo: repo.name,
-                                        name:
-                                            'branch_protection.required_pull_request_reviews.required_approving_review_count',
-                                        msg:
-                                            '"Required approving reviews" must be set to 1'
-                                    });
-                                }
-                            }
-                            if (prot.enforce_admins.enabled !== true) {
-                                checkFailures.push({
-                                    repo: repo.name,
-                                    name:
-                                        'branch_protection.enforce_admins.enabled',
-                                    msg:
-                                        '"Include administrators" must be checked'
-                                });
-                            }
-                            if (prot.restrictions) {
-                                checkFailures.push({
-                                    repo: repo.name,
-                                    name: 'branch_protection.restrictions',
-                                    msg:
-                                        '"Restrict who can push to matching branches" must not be checked'
-                                });
-                            }
-
-                            next();
-                        })
-                        .catch(function(err) {
-                            if (err.message === 'Branch not protected') {
-                                checkFailures.push({
-                                    repo: repo.name,
-                                    name: 'branch_protection',
-                                    msg: 'Must have "master" branch protection'
-                                });
-                                next();
-                            } else if (err.message === 'Branch not found') {
-                                checkWarnings.push({
-                                    repo: repo.name,
-                                    name: 'branch_protection',
-                                    msg: 'No "master" branch (skipping)'
-                                });
-                                next();
-                            } else {
-                                // Avoid deprecation warning by wrapping the error but
-                                // still allowing cmdln to use `err.code`.
-                                //   Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
-                                next(
-                                    new VError(
-                                        {
-                                            name: 'GitHubApiError',
-                                            cause: err,
-                                            code: err.status,
-                                            info: {
-                                                repo: 'joyent/' + repo.name
-                                            }
-                                        },
-                                        'error calling GitHub API'
-                                    )
-                                );
-                            }
-                        });
+                function checkMasterBranchProtection(ctx, next) {
+                    checkBranchProtection('master', ctx, next);
+                },
+                function checkMantaV1BranchProtection(ctx, next) {
+                    checkBranchProtection('mantav1', ctx, next);
                 }
-
-                // TODO: add merge button check (get repo api)
-                // TODO: add wiki check (get repo api)
             ]
         },
         function finish(err) {
             if (err) {
                 cb(err);
             } else {
-                cb(null, checkFailures, checkWarnings);
+                cb(null, checkOpts.checkFailures, checkOpts.checkWarnings);
             }
         }
     );

--- a/lib/cli/github_settings/do_set_branch_protection.js
+++ b/lib/cli/github_settings/do_set_branch_protection.js
@@ -11,6 +11,229 @@ var vasync = require('vasync');
 var VError = require('verror');
 var version = require('../../../package.json').version;
 
+function getBranchProtection(branchName, ctx, next) {
+    assert.string(branchName, 'branchName');
+    assert.object(ctx.octokit, 'ctx.octokit');
+    assert.object(ctx.log, 'ctx.log');
+    assert.string(ctx.repoName, 'ctx.repoName');
+    assert.func(next, 'next');
+
+    var octokit = ctx.octokit;
+    var log = ctx.log;
+    var repoName = ctx.repoName;
+    ctx.missingBranch[branchName] = false;
+
+    octokit.repos
+        .getBranchProtection({
+            owner: 'joyent',
+            repo: repoName,
+            branch: branchName
+        })
+        .then(function(res) {
+            log.trace({ghRes: res}, 'github api response');
+            ctx.protection[branchName] = res.data;
+            next();
+        })
+        .catch(function(err) {
+            if (err.message === 'Branch not protected') {
+                ctx.protection[branchName] = null;
+                next();
+            } else if (err.message === 'Branch not found') {
+                ctx.changeRequired[branchName] = false;
+                ctx.missingBranch[branchName] = true;
+                next();
+            } else {
+                // Avoid deprecation warning by wrapping the error but
+                // still allowing cmdln to use `err.code`.
+                //   Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
+                next(
+                    new VError(
+                        {
+                            name: 'GitHubApiError',
+                            cause: err,
+                            code: err.status,
+                            info: {
+                                repo: 'joyent/' + repoName
+                            }
+                        },
+                        'error calling GitHub API'
+                    )
+                );
+            }
+        });
+}
+
+function determineIfChangeRequired(branchName, ctx, next) {
+    assert.string(branchName, 'branchName');
+    assert.object(ctx.log, 'ctx.log');
+    assert.func(next, 'next');
+
+    var log = ctx.log;
+
+    log.trace(
+        {protection: ctx.protection[branchName]},
+        'determineIfChangeRequired'
+    );
+
+    if (ctx.missingBranch[branchName]) {
+        ctx.changeRequired[branchName] = false;
+        next();
+        return;
+    }
+
+    ctx.changeRequired[branchName] = false;
+    if (ctx.statuses || ctx.unlockUsers) {
+        ctx.changeRequired[branchName] = true;
+    }
+    if (!ctx.protection[branchName]) {
+        ctx.changeRequired[branchName] = true;
+    } else {
+        var pr = ctx.protection[branchName].required_pull_request_reviews;
+        if (!pr) {
+            ctx.changeRequired = true;
+        } else {
+            if (pr.dismiss_stale_reviews !== true) {
+                ctx.changeRequired[branchName] = true;
+            } else if (pr.require_code_owner_reviews !== false) {
+                ctx.changeRequired[branchName] = true;
+            } else if (pr.required_approving_review_count !== 1) {
+                ctx.changeRequired[branchName] = true;
+            }
+        }
+        if (ctx.protection[branchName].enforce_admins.enabled !== true) {
+            ctx.changeRequired[branchName] = true;
+        }
+        if (ctx.protection[branchName].restrictions) {
+            ctx.changeRequired[branchName] = true;
+        }
+    }
+    log.debug(
+        {changeRequired: ctx.changeRequired[branchName]},
+        'changeRequired'
+    );
+    next();
+}
+
+function updateBranchProtection(branchName, ctx, next) {
+    assert.string(branchName, 'branchName');
+    assert.object(ctx.octokit, 'ctx.octokit');
+    assert.string(ctx.repoName, 'ctx.repoName');
+    assert.func(next, 'next');
+
+    var octokit = ctx.octokit;
+    var repoName = ctx.repoName;
+
+    if (!ctx.changeRequired[branchName]) {
+        if (!ctx.missingBranch[branchName]) {
+            console.log('No update required for ' + branchName + ' branch');
+        }
+        next();
+        return;
+    }
+
+    var reqOpts = {};
+    var lockMessage = '';
+
+    if (ctx.unlockUsers) {
+        lockMessage =
+            'Allowing only ' +
+            ctx.unlockUsers.join(', ') +
+            ' to push to "%s" ' +
+            'branch of %s ' +
+            '(https://github.com/joyent/%s/settings/branches)';
+        reqOpts = {
+            owner: 'joyent',
+            repo: repoName,
+            branch: branchName,
+
+            enforce_admins: true,
+            required_pull_request_reviews: null,
+            restrictions: {
+                users: ctx.unlockUsers,
+                teams: []
+            },
+            required_status_checks: null
+        };
+
+        if (
+            ctx.unlockUsers &&
+            ctx.protection[branchName] &&
+            ctx.protection[branchName].required_status_checks &&
+            ctx.protection[branchName].required_status_checks.contexts &&
+            ctx.protection[branchName].required_status_checks.contexts.length >
+                0
+        ) {
+            lockMessage =
+                lockMessage +
+                '\n' +
+                'The following status checks were ' +
+                'disabled:\n    ' +
+                ctx.protection[branchName].required_status_checks.contexts.join(
+                    '\n    '
+                );
+        }
+    } else {
+        lockMessage =
+            'Applying standard branch protection ' +
+            'rules to "%s" branch on repo "%s" ' +
+            '(https://github.com/joyent/%s/settings/branches)';
+        reqOpts = {
+            owner: 'joyent',
+            repo: repoName,
+            branch: branchName,
+            enforce_admins: true,
+            required_pull_request_reviews: {
+                dismissal_restrictions: {},
+                dismiss_stale_reviews: true,
+                require_code_owner_reviews: false,
+                required_approving_review_count: 1
+            },
+            restrictions: null
+        };
+        if (ctx.statuses) {
+            reqOpts.required_status_checks = {
+                contexts: ctx.statuses,
+                strict: true
+            };
+            lockMessage =
+                lockMessage +
+                '\n' +
+                'The following status checks ' +
+                'were enabled:\n    ' +
+                ctx.statuses.join('    \n');
+        } else if (
+            ctx.protection[branchName] &&
+            ctx.protection[branchName].required_status_checks
+        ) {
+            reqOpts.required_status_checks =
+                ctx.protection[branchName].required_status_checks;
+        } else {
+            reqOpts.required_status_checks = null;
+        }
+    }
+    octokit.repos
+        .updateBranchProtection(reqOpts)
+        .then(function(res) {
+            console.log(lockMessage, branchName, repoName, repoName);
+            next();
+        })
+        .catch(function(err) {
+            // Avoid deprecation warning by wrapping the error but
+            // still allowing cmdln to use `err.code`.
+            //   Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
+            next(
+                new VError(
+                    {
+                        name: 'GitHubApiError',
+                        cause: err,
+                        code: err.status
+                    },
+                    'error calling GitHub API'
+                )
+            );
+        });
+}
+
 function do_set_branch_protection(subcmd, opts, args, cb) {
     assert.ok(process.env.GITHUB_TOKEN, 'process.env.GITHUB_TOKEN');
 
@@ -76,194 +299,37 @@ function do_set_branch_protection(subcmd, opts, args, cb) {
                         }
                     );
                 },
-
-                function getMasterBranchProtection(ctx, next) {
-                    octokit.repos
-                        .getBranchProtection({
-                            owner: 'joyent',
-                            repo: repoName,
-                            branch: 'master'
-                        })
-                        .then(function(res) {
-                            log.trace({ghRes: res}, 'github api response');
-                            ctx.masterProt = res.data;
-                            next();
-                        })
-                        .catch(function(err) {
-                            if (err.message === 'Branch not protected') {
-                                ctx.masterProt = null;
-                                next();
-                            } else {
-                                // Avoid deprecation warning by wrapping the error but
-                                // still allowing cmdln to use `err.code`.
-                                //   Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
-                                next(
-                                    new VError(
-                                        {
-                                            name: 'GitHubApiError',
-                                            cause: err,
-                                            code: err.status,
-                                            info: {
-                                                repo: 'joyent/' + repoName
-                                            }
-                                        },
-                                        'error calling GitHub API'
-                                    )
-                                );
-                            }
-                        });
-                },
-
-                function determineIfChangeRequired(ctx, next) {
-                    log.trace(
-                        {masterProt: ctx.masterProt},
-                        'determineIfChangeRequired'
-                    );
-                    ctx.changeRequired = false;
-                    if (ctx.statuses || ctx.unlockUsers) {
-                        ctx.changeRequired = true;
-                    }
-                    if (!ctx.masterProt) {
-                        ctx.changeRequired = true;
-                    } else {
-                        var pr = ctx.masterProt.required_pull_request_reviews;
-                        if (!pr) {
-                            ctx.changeRequired = true;
-                        } else {
-                            if (pr.dismiss_stale_reviews !== true) {
-                                ctx.changeRequired = true;
-                            } else if (
-                                pr.require_code_owner_reviews !== false
-                            ) {
-                                ctx.changeRequired = true;
-                            } else if (
-                                pr.required_approving_review_count !== 1
-                            ) {
-                                ctx.changeRequired = true;
-                            }
-                        }
-                        if (ctx.masterProt.enforce_admins.enabled !== true) {
-                            ctx.changeRequired = true;
-                        }
-                        if (ctx.masterProt.restrictions) {
-                            ctx.changeRequired = true;
-                        }
-                    }
-                    log.debug(
-                        {changeRequired: ctx.changeRequired},
-                        'changeRequired'
-                    );
+                function setupContextObjs(ctx, next) {
+                    // Create context objects to pass into the
+                    // functions which operate on the different
+                    // branches.
+                    ctx.protection = {};
+                    ctx.changeRequired = {};
+                    ctx.missingBranch = {};
+                    ctx.repoName = repoName;
+                    ctx.octokit = octokit;
+                    ctx.log = log;
                     next();
                 },
-
+                // rather than a loop, just operate on each repo in turn
+                function getMasterBranchProtection(ctx, next) {
+                    getBranchProtection('master', ctx, next);
+                },
+                function determineIfMasterChangeRequired(ctx, next) {
+                    determineIfChangeRequired('master', ctx, next);
+                },
                 function updateMasterBranchProtection(ctx, next) {
-                    if (!ctx.changeRequired) {
-                        console.log('No update required');
-                        next();
-                        return;
-                    }
+                    updateBranchProtection('master', ctx, next);
+                },
 
-                    var reqOpts = {};
-                    var lockMessage = '';
-
-                    if (ctx.unlockUsers) {
-                        lockMessage =
-                            'Allowing only ' +
-                            ctx.unlockUsers.join(', ') +
-                            ' to push to "master" ' +
-                            'branch of %s ' +
-                            '(https://github.com/joyent/%s/settings/branches)';
-                        reqOpts = {
-                            owner: 'joyent',
-                            repo: repoName,
-                            branch: 'master',
-
-                            enforce_admins: true,
-                            required_pull_request_reviews: null,
-                            restrictions: {
-                                users: ctx.unlockUsers,
-                                teams: []
-                            },
-                            required_status_checks: null
-                        };
-
-                        if (
-                            ctx.unlockUsers &&
-                            ctx.masterProt &&
-                            ctx.masterProt.required_status_checks &&
-                            ctx.masterProt.required_status_checks.contexts &&
-                            ctx.masterProt.required_status_checks.contexts
-                                .length > 0
-                        ) {
-                            lockMessage =
-                                lockMessage +
-                                '\n' +
-                                'The following status checks were ' +
-                                'disabled:\n    ' +
-                                ctx.masterProt.required_status_checks.contexts.join(
-                                    '\n    '
-                                );
-                        }
-                    } else {
-                        lockMessage =
-                            'Applying standard branch protection ' +
-                            'rules to "master" branch on repo "%s" ' +
-                            '(https://github.com/joyent/%s/settings/branches)';
-                        reqOpts = {
-                            owner: 'joyent',
-                            repo: repoName,
-                            branch: 'master',
-                            enforce_admins: true,
-                            required_pull_request_reviews: {
-                                dismissal_restrictions: {},
-                                dismiss_stale_reviews: true,
-                                require_code_owner_reviews: false,
-                                required_approving_review_count: 1
-                            },
-                            restrictions: null
-                        };
-                        if (ctx.statuses) {
-                            reqOpts.required_status_checks = {
-                                contexts: ctx.statuses,
-                                strict: true
-                            };
-                            lockMessage =
-                                lockMessage +
-                                '\n' +
-                                'The following status checks ' +
-                                'were enabled:\n    ' +
-                                ctx.statuses.join('    \n');
-                        } else if (
-                            opts.masterProt &&
-                            opts.masterProt.required_status_checks
-                        ) {
-                            reqOpts.required_status_checks =
-                                opts.masterProt.required_status_checks;
-                        } else {
-                            reqOpts.required_status_checks = null;
-                        }
-                    }
-                    octokit.repos
-                        .updateBranchProtection(reqOpts)
-                        .then(function(res) {
-                            console.log(lockMessage, repoName, repoName);
-                            next();
-                        })
-                        .catch(function(err) {
-                            // Avoid deprecation warning by wrapping the error but
-                            // still allowing cmdln to use `err.code`.
-                            //   Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
-                            next(
-                                new VError(
-                                    {
-                                        name: 'GitHubApiError',
-                                        cause: err,
-                                        code: err.status
-                                    },
-                                    'error calling GitHub API'
-                                )
-                            );
-                        });
+                function getMantaV1BranchProtection(ctx, next) {
+                    getBranchProtection('mantav1', ctx, next);
+                },
+                function determineIfMantaV1ChangeRequired(ctx, next) {
+                    determineIfChangeRequired('mantav1', ctx, next);
+                },
+                function updateMantaV1BranchProtection(ctx, next) {
+                    updateBranchProtection('mantav1', ctx, next);
                 }
             ]
         },
@@ -313,7 +379,9 @@ do_set_branch_protection.help = [
     '{{options}}',
     '',
     "By default this sets branch protection for the given REPO to Joyent's",
-    'standard settings, which are the following for the "master" branch:',
+    'standard settings for both the "master" and "mantav1" branches,',
+    'if they exist.',
+    'The standard settings for branch protection are:',
     '',
     '    [x] Require pull request reviews before merging',
     '',
@@ -333,12 +401,13 @@ do_set_branch_protection.help = [
     'to pass before allowing PRs to be merged. For example:',
     '    jr gh set-branch-protection -s continuous-integration/jenkins/pr-head,integration-approval REPO',
     '',
-    'The `-U` option can be used to "unlock" the master branch for direct git',
+    'The `-U` option can be used to "unlock" the branches for direct git',
     'merges. It will:',
     '- remove the requirement that merges come from a PR,',
     '- remove any required status checks for merging (for example those added',
     '  with `-s ...`), and',
-    '- restrict who can push to "master" to the given GitHub users or teams',
+    '- restrict who can push to the "master" and "mantav1" branches to the ',
+    '  given GitHub users or teams',
     '',
     'For example the following is commonly used to unlock illumos-joyent for',
     'illumos-gate merges:',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joyent-repos",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joyent-repos",
-  "version": "2.3.1",
+  "version": "2.4.0",
   "description": "A spec and tool for listing, clone, and working with Joyent (Triton, Manta, and SmartOS) repos",
   "author": "Joyent (joyent.com)",
   "license": "MPL-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joyent-repos",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A spec and tool for listing, clone, and working with Joyent (Triton, Manta, and SmartOS) repos",
   "author": "Joyent (joyent.com)",
   "license": "MPL-2.0",


### PR DESCRIPTION
These changes are mostly just lifting the various pipeline functions up into their own separate function, and calling them with a `branchName` parameter as separate pipeline steps for the `master` and `mantav1` branches. There was very little actual code change.