### PR TITLE
TOOLS-2346 set branch protection for Joyent eng repos that were never in gerrit

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,12 @@
 
 ## not yet released
 
+## 2.5.0
+
+- `TOOLS-2346 set branch protection for Joyent eng repos that were never in gerrit`
+  This makes `jr gh check` automatically skip repositories that have
+  `nobranchprotection` set, indicating that no branch protection is required.
+
 ## 2.4.0
 
 - `MANTA-4799 add branch protections on "mantav1" branches of the relevant manta repos`

--- a/lib/cli/github_settings/do_check.js
+++ b/lib/cli/github_settings/do_check.js
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Joyent, Inc.
+ * Copyright 2020 Joyent, Inc.
  *
  * `jr github-settings check [REPOS]`
  */
@@ -145,6 +145,13 @@ function checkBranchProtection(branchName, ctx, next) {
     assert.arrayOfObject(ctx.checkFailures, 'ctx.checkFailures');
     assert.arrayOfObject(ctx.checkWarnings, 'ctx.checkWarnings');
     assert.arrayOfString(ctx.optionalBranches, 'ctx.optionalBranches');
+
+    // If repository metadata says it doesn't need branch protection, return now
+    if (ctx.repo.labels.nobranchprotection) {
+        next();
+        return;
+    }
+
     // https://octokit.github.io/rest.js/#octokit-routes-repos-get-branch-protection
     // https://developer.github.com/v3/repos/branches/#get-branch-protection
     //

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "joyent-repos",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "joyent-repos",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "A spec and tool for listing, clone, and working with Joyent (Triton, Manta, and SmartOS) repos",
   "author": "Joyent (joyent.com)",
   "license": "MPL-2.0",


### PR DESCRIPTION
With this change we have:

```
timf@iorangi (prr-TOOLS-2346) jr ls -l nobranchprotection
NAME           LABELS (flat)
documentation  triton, public=false, meta, nobranchprotection
manta-eng      manta, public=false, nobranchprotection
triton-dev     triton, public=false, nobranchprotection
timf@iorangi (prr-TOOLS-2346)  jr gh check -l nobranchprotection
timf@iorangi (prr-TOOLS-2346)
```

Without this change, we see us complaining, despite not needing branch protection:

```
timf@iorangi (prr-TOOLS-2346) git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
timf@iorangi (master)  jr gh check -l nobranchprotection
documentation#master: error (branch_protection): Must have "master" branch protection
triton-dev#master: error (branch_protection): Must have "master" branch protection
manta-eng#master: error (branch_protection.required_pull_request_reviews): "Require pull request reviews before merging" must be checked
manta-eng#master: error (branch_protection.enforce_admins.enabled): "Include administrators" must be checked
jr github-settings check: error: 4 checks failed
timf@iorangi (master)
```

Something I haven't implemented, was to have `jr gh set-branch-protection` skip these repositories - do you think that's worth doing, or would that be the tool not doing what the user asked for?