### PR TITLE
TOOLS-2432 purge-mg-builds jenkins job is failing: "SyntaxError: Unexpected token function"

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "prettier": "^1.18.2"
   },
   "engines": {
-    "node": ">=4.x"
+    "node": ">=8.x"
   }
 }


### PR DESCRIPTION
This bumps min node version to v8 to reflect reality for this module. See https://jira.joyent.us/browse/TOOLS-2432 for details.